### PR TITLE
[Ready] fix markdown-magic scripts to work for paths with spaces closes #59

### DIFF
--- a/docs/markdown-magic.ts
+++ b/docs/markdown-magic.ts
@@ -11,7 +11,7 @@ const readmePath = path.join(__dirname, "..", "README.md");
 
 const getLastModifiedDate = (folderName: string): string => {
   const directoryPath = path.join(__dirname, "..", "data", folderName);
-  const gitCommand = `git log -1 --format=%cd --date=format:"%B %d, %Y" -- ${directoryPath}`;
+  const gitCommand = `git log -1 --format=%cd --date=format:"%B %d, %Y" -- "${directoryPath}"`;
   const lastModifiedDate = execSync(gitCommand).toString().trim();
   return lastModifiedDate;
 };


### PR DESCRIPTION
added " around path in the git log command to add functionality for absolute paths with spaces