### PR TITLE
feat: make MCP server publishable to npm

### DIFF
--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -8,9 +8,15 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-// When compiled, __dirname is mcp/dist. Data is at repo root: ../../data/json
-// When run from mcp/, __dirname is mcp/dist, so we go up to mcp/ then up to repo root
-const DATA_DIR = join(__dirname, "..", "..", "data", "json");
+// Data is bundled in the dist/data/ directory at build time (via prepublish script).
+// Fallback: when running from source inside the repo, check ../../data/json.
+const BUNDLED_DATA_DIR = join(__dirname, "data");
+const REPO_DATA_DIR = join(__dirname, "..", "..", "data", "json");
+
+import { existsSync } from "fs";
+const DATA_DIR = existsSync(join(BUNDLED_DATA_DIR, "accounts.json"))
+  ? BUNDLED_DATA_DIR
+  : REPO_DATA_DIR;
 
 interface Account {
   address: string;

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,20 +1,45 @@
 {
   "name": "eth-labels-mcp",
   "version": "1.0.0",
-  "description": "MCP server for looking up Ethereum address labels",
+  "description": "MCP server for looking up 170k+ labeled Ethereum addresses and tokens across EVM chains",
   "type": "module",
   "bin": {
     "eth-labels-mcp": "./dist/index.js"
   },
+  "files": [
+    "dist/**/*"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js"
+    "prebuild": "mkdir -p dist/data && cp ../data/json/accounts.json dist/data/accounts.json && cp ../data/json/tokens.json dist/data/tokens.json",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
   },
+  "keywords": [
+    "mcp",
+    "ethereum",
+    "labels",
+    "crypto",
+    "addresses",
+    "model-context-protocol",
+    "claude",
+    "cursor",
+    "ai"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dawsbot/eth-labels.git",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/dawsbot/eth-labels#mcp-server",
+  "license": "MIT",
+  "author": "Dawson Botsford",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/node": "^25.1.0",
     "typescript": "^5.5.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -62,32 +62,149 @@ A public API to consume this data is available for free. You can [use it remotel
 
 ## MCP Server
 
-Use eth-labels as a tool in Claude Code, Cursor, Windsurf, or any MCP-compatible AI assistant. Ask your AI to identify any crypto address or search for known wallets.
+Give your AI the ability to identify any crypto address. Works with Claude, Cursor, Windsurf, VS Code, and any MCP-compatible client.
 
-### Setup
+**170k+ labeled addresses and tokens across EVM chains.**
+
+### Quick Setup
 
 ```sh
-# Clone and build
 git clone https://github.com/dawsbot/eth-labels.git
 cd eth-labels/mcp
 npm install
 npm run build
 ```
 
-### Add to Claude Code
+Then add the server to your AI tool of choice:
 
-Add to your `~/.claude/claude_desktop_config.json`:
+---
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+Run this from your terminal:
+
+```sh
+claude mcp add eth-labels -- node /absolute/path/to/eth-labels/mcp/dist/index.js
+```
+
+Or manually add to `~/.claude.json`:
 
 ```json
 {
   "mcpServers": {
     "eth-labels": {
       "command": "node",
-      "args": ["/path/to/eth-labels/mcp/dist/index.js"]
+      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
     }
   }
 }
 ```
+
+</details>
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+Add to your config file:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "eth-labels": {
+      "command": "node",
+      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving.
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+Open **Settings → Features → MCP Servers → Add new MCP server**, then add:
+
+```json
+{
+  "mcpServers": {
+    "eth-labels": {
+      "command": "node",
+      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Or add to `.cursor/mcp.json` in your project root.
+
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "eth-labels": {
+      "command": "node",
+      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>VS Code (Copilot)</b></summary>
+
+Add to your `.vscode/settings.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "eth-labels": {
+        "command": "node",
+        "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Cline</b></summary>
+
+Open **Cline → MCP Servers → Configure**, then add:
+
+```json
+{
+  "mcpServers": {
+    "eth-labels": {
+      "command": "node",
+      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+</details>
+
+---
+
+> **💡 Tip:** Replace `/absolute/path/to/eth-labels` with where you cloned the repo. Use the full path — relative paths won't work with most MCP clients.
 
 ### Tools
 
@@ -95,7 +212,7 @@ Add to your `~/.claude/claude_desktop_config.json`:
 | ---------------- | ---------------------------------------------------------------------------------- |
 | `lookup_address` | Look up any Ethereum/EVM address to get its label and name tag                     |
 | `search_labels`  | Search by project name, label, or token symbol (e.g. "uniswap", "binance", "USDC") |
-| `dataset_stats`  | Get dataset statistics — 68k+ accounts, 27k+ tokens, 95k+ total entries            |
+| `dataset_stats`  | Get dataset statistics — 115k+ accounts, 54k+ tokens, 170k+ total entries          |
 
 ### Example
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,21 @@ Give your AI the ability to identify any crypto address. Works with Claude, Curs
 
 **170k+ labeled addresses and tokens across EVM chains.**
 
-### Quick Setup
+> **Requires:** Node.js 18+
+
+### Install
+
+#### Option A: npx (no clone needed)
+
+<!-- Coming soon: `npx eth-labels-mcp` -->
+
+```sh
+npm install -g eth-labels-mcp
+```
+
+Then use `eth-labels-mcp` as the command in your client config below (instead of the `node /path/to/...` approach).
+
+#### Option B: From source
 
 ```sh
 git clone https://github.com/dawsbot/eth-labels.git
@@ -75,41 +89,31 @@ npm install
 npm run build
 ```
 
-Then add the server to your AI tool of choice:
+### Add to your AI client
 
----
+After installing, add the server to your tool. Replace `/absolute/path/to/eth-labels` with where you cloned the repo.
 
 <details>
-<summary><b>Claude Code</b></summary>
-
-Run this from your terminal:
+<summary><b>Claude Code</b> (one-liner)</summary>
 
 ```sh
 claude mcp add eth-labels -- node /absolute/path/to/eth-labels/mcp/dist/index.js
 ```
 
-Or manually add to `~/.claude.json`:
-
-```json
-{
-  "mcpServers": {
-    "eth-labels": {
-      "command": "node",
-      "args": ["/absolute/path/to/eth-labels/mcp/dist/index.js"]
-    }
-  }
-}
-```
+That's it. Claude Code handles the rest.
 
 </details>
 
 <details>
 <summary><b>Claude Desktop</b></summary>
 
-Add to your config file:
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+Edit your config file:
+
+| OS | Path |
+|----|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `~/.config/Claude/claude_desktop_config.json` |
 
 ```json
 {
@@ -129,7 +133,7 @@ Restart Claude Desktop after saving.
 <details>
 <summary><b>Cursor</b></summary>
 
-Open **Settings → Features → MCP Servers → Add new MCP server**, then add:
+Add to `.cursor/mcp.json` in your project root (or open **Settings → Features → MCP Servers → Add**):
 
 ```json
 {
@@ -141,8 +145,6 @@ Open **Settings → Features → MCP Servers → Add new MCP server**, then add:
   }
 }
 ```
-
-Or add to `.cursor/mcp.json` in your project root.
 
 </details>
 
@@ -165,9 +167,9 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 </details>
 
 <details>
-<summary><b>VS Code (Copilot)</b></summary>
+<summary><b>VS Code (GitHub Copilot)</b></summary>
 
-Add to your `.vscode/settings.json`:
+Add to `.vscode/settings.json` in your project:
 
 ```json
 {
@@ -202,9 +204,17 @@ Open **Cline → MCP Servers → Configure**, then add:
 
 </details>
 
----
+> **💡 Tip:** Always use absolute paths. Relative paths fail silently in most MCP clients.
 
-> **💡 Tip:** Replace `/absolute/path/to/eth-labels` with where you cloned the repo. Use the full path — relative paths won't work with most MCP clients.
+### Verify it works
+
+Once configured, ask your AI:
+
+```
+Who is 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?
+```
+
+If it responds with "Vitalik Buterin" — you're in.
 
 ### Tools
 


### PR DESCRIPTION
## What

Makes `eth-labels-mcp` ready to publish to npm so anyone can install it without cloning the repo.

## How it works

- **`prebuild` script** copies `data/json/accounts.json` and `data/json/tokens.json` into `dist/data/`
- **`index.ts`** checks for bundled data in `dist/data/` first, falls back to the repo-relative path (`../../data/json`) for local development
- **`prepublishOnly`** auto-runs `npm run build` on `npm publish`
- **`files` field** ensures only `dist/**` ships in the package (no source files)

## Package details

- **Compressed**: 5.2 MB
- **Unpacked**: 31.2 MB (170k entries of address/token labels)
- **Files shipped**: `dist/index.js`, `dist/index.d.ts`, `dist/data/accounts.json`, `dist/data/tokens.json`

## To publish

After merging:

```sh
cd mcp
npm login
npm publish --access public
```

Then users can:

```sh
npm install -g eth-labels-mcp
```

And use `eth-labels-mcp` as the command in any MCP client config — no clone needed.