### PR TITLE
ci: add GitHub Actions workflow for lint, unit tests, and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [v1]
+  pull_request:
+    branches: [v1]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Unit tests
+        run: bun run test:unit
+
+      - name: Typecheck
+        run: bun run build


### PR DESCRIPTION
## Summary

The repo had no `.github/workflows` directory, so eslint and `bun test:unit` only ran via local Husky hooks — external PRs (3 currently open) went completely unverified.

This adds `.github/workflows/ci.yml`, which on pushes and pull requests to `v1`:

- Checks out the repo
- Sets up Bun via `oven-sh/setup-bun@v2`
- `bun install --frozen-lockfile`
- `bun run lint` (eslint)
- `bun run test:unit` (30 unit tests)
- `bun run build` (tsc typecheck)

Integration tests (`test:integration`) are intentionally excluded since they hit live networks.

## Verification

All three commands verified passing locally in a clean worktree off `origin/v1`: lint clean, 30/30 unit tests pass, tsc exits 0, and `bun install --frozen-lockfile` succeeds against the committed `bun.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)